### PR TITLE
Removed roslaunch and roslint as regular depends in CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,6 @@ project(interactive_marker_twist_server)
 find_package(catkin REQUIRED COMPONENTS
   interactive_markers
   roscpp
-  roslaunch
-  roslint
   visualization_msgs)
 
 catkin_package()


### PR DESCRIPTION
Forgot to remove these. All should be well now.  Do only maintainers get emails for build failures?