### PR TITLE
Remove the leading '/' from the default link_name

### DIFF
--- a/src/marker_server.cpp
+++ b/src/marker_server.cpp
@@ -50,7 +50,7 @@ class MarkerServer
     {
       std::string cmd_vel_topic;
 
-      nh.param<std::string>("link_name", link_name, "/base_link");
+      nh.param<std::string>("link_name", link_name, "base_link");
       nh.param<std::string>("robot_name", robot_name, "robot");
 
       if (nh.getParam("linear_scale", linear_drive_scale_map))


### PR DESCRIPTION
The leading `/` character does not appear to be necessary in melodic, and actively causes problems in noetic:

```
/twist_marker_server
Cannot get tf info for init message with sequence number 1. Error: Invalid argument "/base_link" passed to lookupTransform argument source_frame in tf2 frame_ids cannot start with a '/' like: 
```

If the `/` character is required for kinetic, I recommend merging this PR into a new melodic branch for use with melodic & noetic.

Failing that, the docs should be updated to indicate that the `link_name` parameter must be set manually in noetic, as the default won't work correctly.