### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
 add_executable(${PROJECT_NAME} src/marker_server.cpp)
-ament_target_dependencies(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   geometry_msgs
   interactive_markers
   rclcpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,12 @@ find_package(visualization_msgs REQUIRED)
 
 add_executable(${PROJECT_NAME} src/marker_server.cpp)
 target_link_libraries(${PROJECT_NAME} PUBLIC
-  geometry_msgs
-  interactive_markers
-  rclcpp
-  tf2
-  tf2_geometry_msgs
-  visualization_msgs
+  ${geometry_msgs_TARGETS}
+  ${visualization_msgs_TARGETS}
+  interactive_markers::interactive_markers
+  rclcpp::rclcpp
+  tf2::tf2
+  tf2_geometry_msgs::tf2_geometry_msgs
 )
 
 set_target_properties(${PROJECT_NAME}


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
